### PR TITLE
feat: build-script input that runs before codeql/analyze

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
     description: Use CodeQL's auto-build.
     required: false
     default: "false"
+  build-script:
+    description: Optional path to an executable file that will perform a full, uncached, build for CodeQL analysis.
+    required: false
   languages:
     description: The languages of the checks to run, separated by a comma. Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support.
     required: true
@@ -18,11 +21,10 @@ inputs:
     required: false
     default: "."
 
-
 runs:
   using: composite
   steps:
-    - name: Write config
+    - name: Write CodeQL config file
       id: config
       shell: bash
       run: |
@@ -32,6 +34,8 @@ runs:
         cat > "$outputFile" <<'EOF'
         paths:
           - ${{ inputs.working-directory }}
+        queries:
+          - uses: security-extended
         EOF
         echo "output-file=$outputFile" >> $GITHUB_OUTPUT
 
@@ -44,6 +48,13 @@ runs:
     - if: inputs.auto-build == 'true'
       name: Auto-build
       uses: github/codeql-action/autobuild@v2
+
+    - name: Execute build script
+      if: inputs.build-script != ''
+      env:
+        BUILD_SCRIPT: ${{ inputs.build-script }}
+      working-directory: ${{ inputs.working-directory }}
+      run: exec "$(realpath "$BUILD_SCRIPT")"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,7 @@ runs:
       if: inputs.build-script != ''
       env:
         BUILD_SCRIPT: ${{ inputs.build-script }}
+      shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: exec "$(realpath "$BUILD_SCRIPT")"
 

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,6 @@ runs:
         cat > "$configFile" <<'EOF'
         paths:
           - ${{ inputs.working-directory }}
-        queries:
-          - uses: security-extended
         EOF
         echo "config-file=$configFile" >> $GITHUB_OUTPUT
 
@@ -44,6 +42,7 @@ runs:
       with:
         config-file: ${{ steps.config.outputs.config-file }}
         languages: ${{ inputs.languages }}
+        queries: security-extended
 
     - if: inputs.auto-build == 'true'
       name: Auto-build

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,8 @@ runs:
         cat > "$configFile" <<'EOF'
         paths:
           - ${{ inputs.working-directory }}
+        queries:
+          - uses: security-extended
         EOF
         echo "config-file=$configFile" >> $GITHUB_OUTPUT
 
@@ -42,7 +44,6 @@ runs:
       with:
         config-file: ${{ steps.config.outputs.config-file }}
         languages: ${{ inputs.languages }}
-        queries: security-extended
 
     - if: inputs.auto-build == 'true'
       name: Auto-build

--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,13 @@ runs:
     - name: Write CodeQL config file
       id: config
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       run: |
-        buildDir=$(realpath ./build)
+        buildDir="${{ inputs.working-directory }}/build"
         configFile="${buildDir}/codeqlconfig.yaml"
         mkdir -p "$buildDir"
-        cat > "$configFile" <<EOF
+        cat > "$configFile" <<'EOF'
         paths:
-          - $(pwd)
+          - ${{ inputs.working-directory }}
         queries:
           - uses: security-extended
         EOF
@@ -52,11 +51,9 @@ runs:
 
     - name: Execute build script
       if: inputs.build-script != ''
-      env:
-        BUILD_SCRIPT: ${{ inputs.build-script }}
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      run: exec "$(realpath "$BUILD_SCRIPT")"
+      run: |
+        exec "${{ inputs.working-directory }}/${{ inputs.build-script }}"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,14 @@ runs:
     - name: Write CodeQL config file
       id: config
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
-        parentDir=${{ inputs.working-directory }}/build
+        parentDir=$(realpath ./build)
         outputFile=${parentDir}/codeqlconfig.yaml
         mkdir -p "$parentDir"
         cat > "$outputFile" <<'EOF'
         paths:
-          - ${{ inputs.working-directory }}
+          - $(pwd)
         queries:
           - uses: security-extended
         EOF

--- a/action.yml
+++ b/action.yml
@@ -29,21 +29,21 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        parentDir=$(realpath ./build)
-        outputFile=${parentDir}/codeqlconfig.yaml
-        mkdir -p "$parentDir"
-        cat > "$outputFile" <<'EOF'
+        buildDir=$(realpath ./build)
+        configFile="${buildDir}/codeqlconfig.yaml"
+        mkdir -p "$buildDir"
+        cat > "$configFile" <<EOF
         paths:
           - $(pwd)
         queries:
           - uses: security-extended
         EOF
-        echo "output-file=$outputFile" >> $GITHUB_OUTPUT
+        echo "config-file=$configFile" >> $GITHUB_OUTPUT
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        config-file: ${{ steps.config.outputs.output-file }}
+        config-file: ${{ steps.config.outputs.config-file }}
         languages: ${{ inputs.languages }}
 
     - if: inputs.auto-build == 'true'


### PR DESCRIPTION
Compiled languages must perform a full compilation between `codeql/init` and `codeql/analyze`. This optional input will run when appropriate and expects a path to executable file.